### PR TITLE
I hope this helps a bit

### DIFF
--- a/AntiTranslate.user.js
+++ b/AntiTranslate.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Youtube Auto-translate Canceler
 // @namespace    https://github.com/adriaan1313/YoutubeAutotranslateCanceler
-// @version      0.69.4
+// @version      0.70.0
 // @description  Remove auto-translated youtube titles
 // @author       Pierre Couy
 // @match        https://www.youtube.com/*

--- a/AntiTranslate.user.js
+++ b/AntiTranslate.user.js
@@ -90,16 +90,19 @@ const DESCRIPTION_POLLING_INTERVAL = 200;
 
         // REFERENCED VIDEO TITLES - find video link elements in the page that have not yet been changed
         var links = Array.prototype.slice.call(document.getElementsByTagName("a")).filter(a => {
+            const bounds = a.getBoundingClientRect();
             return (a.id == 'video-title-link' || a.id == 'video-title' || a.classList.contains("yt-lockup-metadata-view-model-wiz__title")) &&
                 !a.classList.contains("ytd-video-preview") &&
                 !(a.href.includes("list=") && !(a.classList.contains("ytd-playlist-video-renderer") || a.classList.contains("ytd-playlist-panel-video-renderer"))) &&
-                !a.href.includes("/clip/") &&
+                !a.href.includes("/clip/") && bounds.width > 0 && bounds.height > 0 &&
                 alreadyChanged.indexOf(a) == -1;
         });
 
         var spans = Array.prototype.slice.call(document.getElementsByTagName("span")).filter(a => {
+            const bounds = a.getBoundingClientRect();
             return a.id == 'video-title' &&
                 !(a.parentNode.href?.includes("list=") || a.classList.contains("ytd-radio-renderer") || a.classList.contains("ytd-playlist-renderer" || a.parentNode.href?.includes("/clip/")) ) &&
+                bounds.width > 0 && bounds.height > 0 &&
                 alreadyChanged.indexOf(a) == -1;
         });
 


### PR DESCRIPTION
- Fix problem where things get swapped with or appended to the wrong video (maybe?)
- Exclude clips
- Unexclude links that are part of a playlist but not to the playlist
- Make it so no epmty requests are sent to the api (eg where `...&id=&key=...`)

- [x] Make sure it doesn't break any pages (like send fifty billion api requests or something
  - [x] Home
  - [x] Subscriptions
  - [x] Watch
  - [x] Watch in playlist
  - [x] Shorts 
  - [x] Playlist
  - [x] You feed
  - [x] History feed
  - [x] Trending feed
  - [x] Clips feed
  - [x] Playlists feed
  - [x] Storefront feed
  - [x] Gaming page
  - [x] Podcasts page
  - [x] Channel main page
  - [x] Channel videos/live
  - [x] Channel shorts
  - [x] Channel playlists
  - [x] Channel podcasts
  - [x] Channel posts
  - [x] Channel store